### PR TITLE
Fix Type mismatch errors when using strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+tests
+ubx
+use-ubasic

--- a/tests.c
+++ b/tests.c
@@ -114,7 +114,7 @@ void run(const char program[]) {
 
 void clear_display(void)
 {
-  write(1, "\012", 1);
+  putchar('\012');
 }
 
 int move_cursor(int x, int y)

--- a/ubasic.c
+++ b/ubasic.c
@@ -629,8 +629,8 @@ static void relation(struct typevalue *r1)
       r1->d.i = n;
     }
     op = current_token;
+    r1->type = TYPE_INTEGER;
   }
-  r1->type = TYPE_INTEGER;
 }
 /*---------------------------------------------------------------------------*/
 static void expr(struct typevalue *r1)
@@ -659,8 +659,8 @@ static void expr(struct typevalue *r1)
         break;
     }
     op = current_token;
+    r1->type = TYPE_INTEGER;
   }
-  r1->type = TYPE_INTEGER;
 }
 /*---------------------------------------------------------------------------*/
 static value_t intexpr(void)


### PR DESCRIPTION
As written, `void expr(struct typevalue *)` and `void relation(struct typevalue *)` always set the `type` member of their arguments to `TYPE_INTEGER`.

For expressions such as `"Hello, World!"`, where no comparisons take place, this isn't desirable, as programs such as

```basic
10 A$ = "Hello, World!"
```

will fail (`10: Type mismatch error.`).