### PR TITLE
Add crlf handling, END statement, & IF ... THEN line-number

### DIFF
--- a/tokenizer.c
+++ b/tokenizer.c
@@ -2,6 +2,9 @@
  * Copyright (c) 2006, Adam Dunkels
  * All rights reserved.
  *
+ * Copyright (c) 2018, TK Chia
+ * All rights reserved.
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -84,6 +87,7 @@ static const struct keyword_token keywords[] = {
   {"code", TOKENIZER_CODE},
   {"val", TOKENIZER_VAL},
   {"stop", TOKENIZER_STOP},
+  {"end", TOKENIZER_END},
   {"and", TOKENIZER_AND},
   {"or", TOKENIZER_OR},
   {"dim", TOKENIZER_DIM},
@@ -117,6 +121,10 @@ static uint8_t doublechar(void)
     return TOKENIZER_NE;
   if (*ptr == '*' && ptr[1] == '*')
     return TOKENIZER_POWER;
+  if (*ptr == '\r' && ptr[1] == '\n')
+    return TOKENIZER_NL;
+  if (*ptr == '\n' && ptr[1] == '\r')
+    return TOKENIZER_NL;
   return 0;
 }
 
@@ -125,6 +133,8 @@ static uint8_t singlechar(void)
 {
   if (strchr("\n,;+-&|*/(#)<>=^:?", *ptr))
     return *ptr;
+  if (*ptr == '\r')
+    return TOKENIZER_NL;
   /* Not semantically meaningful */
   return 0;
 }
@@ -172,7 +182,7 @@ static uint8_t get_next_token(void)
     nextptr = ptr;
     do {
       ++nextptr;
-      if (!*nextptr || *nextptr == '\n')
+      if (!*nextptr || *nextptr == '\n' || *nextptr == '\r')
         ubasic_tokenizer_error();
     } while(*nextptr != '"');
     ++nextptr;
@@ -250,7 +260,7 @@ void tokenizer_next(void)
 
 void tokenizer_newline(void)
 {
-   while(!(*nextptr == '\n' || tokenizer_finished())) {
+   while(!(*nextptr == '\n' || *nextptr == '\r' || tokenizer_finished())) {
      ++nextptr;
   }
   tokenizer_next();

--- a/tokenizer.h
+++ b/tokenizer.h
@@ -5,6 +5,9 @@
  * Copyright (c) 2015, Alan Cox
  * All rights reserved.
  *
+ * Copyright (c) 2018, TK Chia
+ * All rights reserved.
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -82,6 +85,7 @@
 #define TOKENIZER_RIGHTSTR	((uint8_t)227)
 #define TOKENIZER_MIDSTR	((uint8_t)228)
 #define TOKENIZER_CHRSTR	((uint8_t)229)
+#define TOKENIZER_END		((uint8_t)230)
   /* Tokens that are single symbol assigned to themselves for efficiency */
 #define TOKENIZER_COMMA		((uint8_t)',')
 #define TOKENIZER_SEMICOLON	((uint8_t)';')
@@ -100,7 +104,7 @@
 #define TOKENIZER_POWER		((uint8_t)'^')
 #define TOKENIZER_COLON		((uint8_t)':')
 #define TOKENIZER_QUESTION 	((uint8_t)'?')
-#define TOKENIZER_CR		((uint8_t)'\n')
+#define TOKENIZER_NL		((uint8_t)'\n')
 
 
 #define TOKENIZER_NUMEXP(x)		(((x) & 0xE0) == 0xC0)

--- a/ubasic.c
+++ b/ubasic.c
@@ -842,7 +842,11 @@ static void charreset(void)
 
 static void chartab(value_t v)
 {
-  while(chpos < v)
+  if (v < 1)
+    v = 1;
+  if (chpos >= v)
+    charout('\n', NULL);
+  while(chpos < v - 1)
     charout(' ', NULL);
 }
 


### PR DESCRIPTION
Changes with this patch:

  * The parser now accepts `"\r\n"`, `"\n\r"`, and `"\r"` as line delimiters, so that `.bas` files which have MS-DOS line endings (`"\r\n"`) now parse right.
  * `END` is now supported (again), as a synonym for `STOP`. [ECMA-55](https://www.ecma-international.org/publications/files/ECMA-ST-WITHDRAWN/ECMA-55,%201st%20Edition,%20January%201978.pdf) expects an `END` word on the last line of a program (§5.4).
  * The `IF` ... `THEN` _line-number_ syntax is now supported. Apparently this is the `IF` ... syntax required by ECMA-55 (§12.2) --- which makes the `IF` ... `THEN` _statement_ syntax actually an extension.